### PR TITLE
Fix dockerfile for new nss scraper

### DIFF
--- a/nss.dockerfile
+++ b/nss.dockerfile
@@ -22,6 +22,7 @@ RUN npm ci
 # JSON and sql should be in working directory of project
 # Root sql should be sibling of project directory
 COPY --from=builder /app/dist ./dist
+COPY nss/nss_data ./nss_data
 COPY nss/buildingOverrides.json ./
 COPY nss/roomOverrides.json ./
 COPY nss/sql ./sql


### PR DESCRIPTION
Should fix this error from Argo.

```
> nss-scraper@1.0.0 start
> node ./dist/runScraper.js
Scraping 2026
Url to hit: http://hasuragres.hasuragres.svc.cluster.local:80
Maximum Concurrent Requests: 1
Minimum Time (ms) Between Requests: 1000
node:fs:453
    return binding.readFileUtf8(path, stringToFlags(options.flag));
                   ^
Error: ENOENT: no such file or directory, open '/app/nss_data/buildings.json'
    at Object.readFileSync (node:fs:453:20)
    at runScrapeJob (/app/dist/runScraper.js:14:47)
    at runScraper (/app/dist/runScraper.js:32:62)
    at Object.<anonymous> (/app/dist/runScraper.js:101:1)
    at Module._compile (node:internal/modules/cjs/loader:1376:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1435:10)
    at Module.load (node:internal/modules/cjs/loader:1207:32)
    at Module._load (node:internal/modules/cjs/loader:1023:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:135:12)
    at node:internal/main/run_main_module:28:49 {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: '/app/nss_data/buildings.json'
}
```