### PR TITLE
chore(actions): replace deployment PAT with app dispatch

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -72,7 +72,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
     steps:
       - name: Dispatch deployment
-        uses: devsoc-unsw/deployment-dispatch-action@a115e2ad9226805cd2588dc6fa5b7775991b141a
+        uses: devsoc-unsw/deployment-dispatch-action@main
         with:
           deployment-dispatcher-app-id: ${{ vars.DEPLOYMENT_DISPATCHER_APP_ID }}
           deployment-dispatcher-app-private-key: ${{ secrets.DEPLOYMENT_DISPATCHER_APP_PRIVATE_KEY }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ github.token }}
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
@@ -71,28 +71,11 @@ jobs:
     needs: [ build ]
     if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - name: Dispatch deployment
+        uses: devsoc-unsw/deployment-dispatch-action@a115e2ad9226805cd2588dc6fa5b7775991b141a
         with:
-          repository: devsoc-unsw/deployment
-          ref: dev
-          token: ${{ secrets.GH_TOKEN }}
-      - name: Install yq
-        uses: mikefarah/yq@v4.40.5
-      - name: Update deployment
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-        run: |
-          git config user.name "CSESoc CD"
-          git config user.email "technical@csesoc.org.au"
-
-          git checkout -b update/freerooms-scrapers/${{ github.sha }}
-          yq -i '.spec.jobTemplate.spec.template.spec.containers[0].image = "ghcr.io/devsoc-unsw/freerooms-nss-scraper:${{ github.sha }}"' projects/nss-scraper/nss-scraper.yml
-          yq -i '.spec.jobTemplate.spec.template.spec.containers[0].image = "ghcr.io/devsoc-unsw/freerooms-libcal-scraper:${{ github.sha }}"' projects/libcal-scraper/libcal-scraper.yml
-          
-          git add . 
-          git commit -m "feat(freerooms-scrapers): update images" 
-          git push -u origin update/freerooms-scrapers/${{ github.sha }}
-          gh pr create -B dev --title "feat(freerooms-scrapers): update images" --body "Updates the images for the nss-scraper and libcal-scraper deployments to commit devsoc-unsw/freerooms-scrapers@${{ github.sha }}." > URL
-          gh pr merge $(cat URL) --squash -d
-          
+          deployment-dispatcher-app-id: ${{ vars.DEPLOYMENT_DISPATCHER_APP_ID }}
+          deployment-dispatcher-app-private-key: ${{ secrets.DEPLOYMENT_DISPATCHER_APP_PRIVATE_KEY }}
+          updates: |
+            ghcr.io/devsoc-unsw/freerooms-nss-scraper=${{ github.sha }}
+            ghcr.io/devsoc-unsw/freerooms-libcal-scraper=${{ github.sha }}


### PR DESCRIPTION
## Summary
Use the shared `deployment-dispatch-action` in `.github/workflows/docker.yml` instead of directly checking out and editing `devsoc-unsw/deployment` from this repo's workflow.

## Changes
- replace the current deploy step flow with `devsoc-unsw/deployment-dispatch-action@main`
- rename the app credentials to `vars.DEPLOYMENT_DISPATCHER_APP_ID` and `secrets.DEPLOYMENT_DISPATCHER_APP_PRIVATE_KEY`
- switch GHCR publish authentication to `github.token`
- remove all remaining `GH_TOKEN` and old `IMAGE_UPDATER_*` references from the repo
- keep the existing workflow shape, runner selection, and action versions unless a change was required to remove `GH_TOKEN` or preserve `packages: write` for GHCR publishing

## Context
The action repository currently exposes `main` but does not expose a `v1` tag or `v1` branch, so this PR uses `@main` rather than a pinned commit SHA.

## Verification
- `yq eval '.' .github/workflows/docker.yml > /dev/null`
- `rg -n "\bGH_TOKEN\b|\bIMAGE_UPDATER_APP_ID\b|\bIMAGE_UPDATER_APP_PRIVATE_KEY\b" . -S -g '!node_modules'` returns no matches
- `actionlint -color .github/workflows/docker.yml` still reports pre-existing baseline issues in some repos, such as old major action refs and missing `steps.meta` definitions
